### PR TITLE
Fixes current Travis build failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 language: android
 android:
   components:
@@ -28,7 +28,6 @@ cache:
 before_install:
   - export GRADLE_OPTS="-Dorg.gradle.daemon=false -Xmx3072m $GRADLE_OPTS"
   - export DEFAULT_JVM_OPTS=
-  - echo y | android update sdk -u -a -t tools
 
 install: true
 


### PR DESCRIPTION
fixes #129 

* Updated travis script to set sudo: true.
* Travis script will no longer download the most recent Android SDK tools.