### PR TITLE
#258 add checksums to non snapshot releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: android
 android:
   components:
     - tools
-    - build-tools-25.0.3
+    - build-tools-25.0.2
     - android-23
     - extra-android-m2repository
 

--- a/build-support/emp3-gradle-plugin/src/main/resources/common.gradle
+++ b/build-support/emp3-gradle-plugin/src/main/resources/common.gradle
@@ -21,7 +21,7 @@ ext {
     android_minSdkVersion     = 19
     android_targetSdkVersion  = 23
     android_compileSdkVersion = 23
-    android_buildToolsVersion = "25.0.3"
+    android_buildToolsVersion = "25.0.2"
 }
 
 group = "mil.army.missioncommand"

--- a/mapengine/worldwind/apk/build.gradle
+++ b/mapengine/worldwind/apk/build.gradle
@@ -15,6 +15,15 @@ android {
         applicationId "mil.emp3.worldwind"
     }
 
+    build.doLast { task ->
+        def sourceDir = "$projectDir/build/outputs/apk/"
+        def fileName = "mapengine-worldwind-apk-release-unsigned.apk"
+        
+        def checksumTarget = sourceDir + fileName
+        ant.checksum file: checksumTarget, algorithm: "MD5", fileExt: ".md5"
+        ant.checksum file: checksumTarget, algorithm: "SHA-256", fileExt: ".sha256"
+    }
+
     // Add map engine id and version information to BuildConfig to be retrieved by About class.
     // Following is temporarily commented out until NASA publishes a version release to maven.
 //    buildTypes.each {

--- a/mapengine/worldwind/build.gradle
+++ b/mapengine/worldwind/build.gradle
@@ -5,9 +5,25 @@ publishing.publications {
     nebula(MavenPublication) {
         artifactId = "emp3-android-worldwind"
 
-        artifacts = [
-            "$buildDir/../aar/build/outputs/aar/mapengine-worldwind-aar-release.aar",
-            "$buildDir/../apk/build/outputs/apk/mapengine-worldwind-apk-debug.apk"
-        ]
+        artifact("$buildDir/../apk/build/outputs/apk/mapengine-worldwind-apk-release-unsigned.apk.md5") {
+            extension "apk.md5"
+        }
+
+        artifact("$buildDir/../aar/build/outputs/aar/mapengine-worldwind-aar-release.aar") {
+            extension "aar"
+        }
+
+        artifact("$buildDir/../apk/build/outputs/apk/mapengine-worldwind-apk-release-unsigned.apk.sha256") {
+            extension "apk.sha256"
+        }
+
+        artifact("$buildDir/../apk/build/outputs/apk/mapengine-worldwind-apk-release-unsigned.apk") {
+            extension "apk"
+        }
+
+        artifact("$buildDir/../apk/build/outputs/apk/mapengine-worldwind-apk-debug.apk") {
+            classifier "debug"
+            extension "apk"
+        }
     }
 }

--- a/sdk/sdk-core/apk/build.gradle
+++ b/sdk/sdk-core/apk/build.gradle
@@ -8,4 +8,13 @@ android {
     defaultConfig {
         applicationId "mil.emp3.emp3_android_sdk_core_apk"
     }
+
+    build.doLast { task ->
+        def sourceDir = "$projectDir/build/outputs/apk/"
+        def fileName = "emp3-android-sdk-core-apk-release-unsigned.apk"
+        
+        def checksumTarget = sourceDir + fileName
+        ant.checksum file: checksumTarget, algorithm: "MD5", fileExt: ".md5"
+        ant.checksum file: checksumTarget, algorithm: "SHA-256", fileExt: ".sha256"
+    }
 }

--- a/sdk/sdk-core/build.gradle
+++ b/sdk/sdk-core/build.gradle
@@ -5,9 +5,25 @@ publishing.publications {
     nebula(MavenPublication) {
         artifactId = "emp3-android-sdk-core"
 
-        artifacts = [
-            "$buildDir/../aar/build/outputs/aar/emp3-android-sdk-core-aar-release.aar",
-            "$buildDir/../apk/build/outputs/apk/emp3-android-sdk-core-apk-debug.apk"
-        ]
+        artifact("$buildDir/../aar/build/outputs/aar/emp3-android-sdk-core-aar-release.aar") {
+            extension "aar"
+        }
+
+        artifact("$buildDir/../apk/build/outputs/apk/emp3-android-sdk-core-apk-release-unsigned.apk") {
+            extension "apk"
+        }
+
+        artifact("$buildDir/../apk/build/outputs/apk/emp3-android-sdk-core-apk-debug.apk") {
+            classifier "debug"
+            extension "apk"
+        }
+
+        artifact("$buildDir/../apk/build/outputs/apk/emp3-android-sdk-core-apk-release-unsigned.apk.md5") {
+            extension "apk.md5"
+        }
+
+        artifact("$buildDir/../apk/build/outputs/apk/emp3-android-sdk-core-apk-release-unsigned.apk.sha256") {
+            extension "apk.sha256"
+        }
     }
 }


### PR DESCRIPTION
Publish SHA-256 and MD5 checksums for the following artifacts:

* emp3-android-worldwind.apk
* emp3-android-sdk-core.apk