### PR TITLE
#302 event not fired

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=3.0.1
+version=3.0.2-SNAPSHOT
 org.gradle.jvmargs=-Xmx2048M
 

--- a/sdk/sdk-core/aar/src/main/java/mil/emp3/core/editors/PolygonEditor.java
+++ b/sdk/sdk-core/aar/src/main/java/mil/emp3/core/editors/PolygonEditor.java
@@ -199,6 +199,13 @@ public class PolygonEditor extends AbstractDrawEditEditor<Polygon> {
                 // Get the distance and bearing between this one and the afterCP and create the new CP
                 this.createCPBetween(oLatLon, afterCP.getPosition(), ControlPoint.CPTypeEnum.NEW_POSITION_CP, cpIndex + 1, (cpIndex + 2) % posList.size());
 
+                // if we completed a polygon for the first time, the only green dot became blue and
+                // there are now three sides but only the two green dots created above.  We need to
+                // restore the original green dot control point
+                if (posList.size() == 3) {
+                    this.createCPBetween(beforeCP.getPosition(), afterCP.getPosition(), ControlPoint.CPTypeEnum.NEW_POSITION_CP,
+                            (cpIndex + 2) % posList.size(), (cpIndex + 3) % posList.size());
+                }
                 // Now we add event update data.
                 this.addUpdateEventData(FeatureEditUpdateTypeEnum.COORDINATE_ADDED, new int[]{oCP.getCPIndex()});
                 moved = true;

--- a/sdk/sdk-core/aar/src/main/java/mil/emp3/core/editors/milstd/MilStdDCTwoPointEditor.java
+++ b/sdk/sdk-core/aar/src/main/java/mil/emp3/core/editors/milstd/MilStdDCTwoPointEditor.java
@@ -102,6 +102,7 @@ public class MilStdDCTwoPointEditor extends AbstractMilStdMultiPointEditor {
         controlPoint.setPosition(pos);
         cpList.add(controlPoint);
         posList.add(0, pos);
+        this.addUpdateEventData(FeatureEditUpdateTypeEnum.COORDINATE_ADDED, new int[]{controlPoint.getCPIndex()});
 
         return cpList;
     }


### PR DESCRIPTION
This fixes issue #303 which says artifacts are left behind.  The issue was traced to a problem with control points.  When a polygon is completed for the first time by dragging a green dot, the green dot turns blue, but the original green dot is not restored.  This problem does not occur with a completed polygon.