### PR TITLE
Adds ability to configure label text outline and fill color.

### DIFF
--- a/mapengine/worldwind/apk/src/main/java/mil/emp3/worldwind/feature/EMPtoWWFeatureConverter.java
+++ b/mapengine/worldwind/apk/src/main/java/mil/emp3/worldwind/feature/EMPtoWWFeatureConverter.java
@@ -229,6 +229,7 @@ public class EMPtoWWFeatureConverter {
             selectedLabelStyle = getMapInstance().getEmpResources().getSelectedLabelStyle(getMapInstance());
             if (null != selectedLabelStyle) {
                 textAttribute.setTextColor(Conversion.convertColor(selectedLabelStyle.getColor()));
+                textAttribute.setOutlineColor(Conversion.convertColor(selectedLabelStyle.getOutlineColor()));
             }
             textAttribute.setEnableOutline(true);
             textAttribute.setOutlineWidth(TEXT_OUTLINE_WIDTH);
@@ -237,6 +238,7 @@ public class EMPtoWWFeatureConverter {
         if (null != labelStyle) {
             if (!isSelected && (null != labelStyle.getColor())) {
                 textAttribute.setTextColor(Conversion.convertColor(labelStyle.getColor()));
+                textAttribute.setOutlineColor(Conversion.convertColor(labelStyle.getOutlineColor()));
             }
 
             switch (labelStyle.getJustification()) {

--- a/mapengine/worldwind/apk/src/main/java/mil/emp3/worldwind/feature/MilStd2525SinglePoint.java
+++ b/mapengine/worldwind/apk/src/main/java/mil/emp3/worldwind/feature/MilStd2525SinglePoint.java
@@ -1,20 +1,14 @@
 package mil.emp3.worldwind.feature;
 
-import android.util.Log;
 import android.util.SparseArray;
 
-import org.cmapi.primitives.GeoLabelStyle;
-import org.cmapi.primitives.IGeoColor;
-import org.cmapi.primitives.IGeoLabelStyle;
 import org.cmapi.primitives.IGeoPosition;
 
 import gov.nasa.worldwind.WorldWind;
 import gov.nasa.worldwind.geom.Position;
 import gov.nasa.worldwind.render.RenderContext;
-import gov.nasa.worldwind.render.Renderable;
 import gov.nasa.worldwind.shape.Placemark;
 import mil.emp3.api.MilStdSymbol;
-import mil.emp3.api.utils.EmpGeoColor;
 import mil.emp3.mapengine.interfaces.IMilStdRenderer;
 import mil.emp3.worldwind.MapInstance;
 import mil.emp3.worldwind.feature.support.MilStd2525LevelOfDetailSelector;
@@ -42,10 +36,10 @@ public class MilStd2525SinglePoint extends FeatureRenderableMapping<MilStdSymbol
 
     public MilStd2525SinglePoint(MapInstance mapInstance, IMilStdRenderer iconRenderer, Position position, MilStdSymbol symbol) {
         super(symbol, mapInstance);
+
         this.placemark = new EMPPlacemark(this, position);
         this.sSymbolCode = symbol.getSymbolCode();
         this.oRenderer = iconRenderer;
-        initializeDefaultAttributes(symbol);
         this.setSymbolAttributes();
         this.setSymbolModifiers();
         placemark.setPickDelegate(symbol);
@@ -77,15 +71,6 @@ public class MilStd2525SinglePoint extends FeatureRenderableMapping<MilStdSymbol
     private void setSymbolAttributes() {
         this.oAttributes = this.oRenderer.getAttributes(this.getMapInstance(), this.getFeature(), this.isSelected());
         this.getSymbol().setSymbolAttributes(this.oAttributes);
-    }
-
-    // Takes a symbol and initializes default color values for labels.
-    private static void initializeDefaultAttributes(MilStdSymbol symbol) {
-        // Initializes default text color to black and white.
-        final IGeoLabelStyle labelStyle = new GeoLabelStyle();
-        labelStyle.setColor(EmpGeoColor.BLACK);
-        labelStyle.setOutlineColor(EmpGeoColor.WHITE);
-        symbol.setLabelStyle(labelStyle);
     }
 
     public SparseArray getSymbolModifiers() {
@@ -172,45 +157,5 @@ public class MilStd2525SinglePoint extends FeatureRenderableMapping<MilStdSymbol
         super.setSelected(selected);
         setSymbolAttributes();
         setSymbolModifiers();
-    }
-
-    /**
-     * Sets icon color of underlying symbol and causes a re-render.
-     * @param iconColor {@link IGeoColor} color to render icon in.
-     */
-    public void setIconColor(final IGeoColor iconColor) {
-        this.oFeature.setIconColor(iconColor);
-        this.setDirty(true);
-    }
-
-    /**
-     * Sets fill color of the underlying symbol and causes a re-render.
-     * @param fillColor {@link IGeoColor} color to render fill in.
-     */
-    public void setFillColor(final IGeoColor fillColor) {
-        this.oFeature.setFillColor(fillColor);
-        this.setDirty(true);
-    }
-
-    /**
-     * Sets the line color of the underlying symbol and causes a re-render.
-     * @param lineColor {@link IGeoColor} color to render line in.
-     */
-    public void setLineColor(final IGeoColor lineColor) {
-        this.oFeature.setLineColor(lineColor);
-        this.setDirty(true);
-    }
-
-    /**
-     * Convenience method to color fill, line and icon in one call.
-     * @param fillColor - Color of the fill.
-     * @param lineColor - Color of the line.
-     * @param iconColor - Color of the icon.
-     */
-    public void styleSymbol(final IGeoColor fillColor, final IGeoColor lineColor, final IGeoColor iconColor) {
-        this.setFillColor(fillColor);
-        this.setLineColor(lineColor);
-        this.setIconColor(iconColor);
-        this.setDirty(true);
     }
 }

--- a/mapengine/worldwind/apk/src/main/java/mil/emp3/worldwind/feature/MilStd2525SinglePoint.java
+++ b/mapengine/worldwind/apk/src/main/java/mil/emp3/worldwind/feature/MilStd2525SinglePoint.java
@@ -45,7 +45,7 @@ public class MilStd2525SinglePoint extends FeatureRenderableMapping<MilStdSymbol
         this.oRenderer = iconRenderer;
         this.setSymbolAttributes();
         this.setSymbolModifiers();
-        this.initializeDefaultAttributes(symbol);
+        initializeDefaultAttributes(symbol);
         placemark.setPickDelegate(symbol);
         switch (symbol.getAltitudeMode()) {
             case RELATIVE_TO_GROUND:
@@ -77,7 +77,8 @@ public class MilStd2525SinglePoint extends FeatureRenderableMapping<MilStdSymbol
         this.getSymbol().setSymbolAttributes(this.oAttributes);
     }
 
-    private void initializeDefaultAttributes(MilStdSymbol symbol) {
+    // Takes a symbol and initializes default color values for labels.
+    private static void initializeDefaultAttributes(MilStdSymbol symbol) {
         // Initializes default text color to black and white.
         final IGeoColor black = new EmpGeoColor(0, 0, 0);
         final IGeoColor white = new EmpGeoColor(255, 255, 255);

--- a/mapengine/worldwind/apk/src/main/java/mil/emp3/worldwind/feature/MilStd2525SinglePoint.java
+++ b/mapengine/worldwind/apk/src/main/java/mil/emp3/worldwind/feature/MilStd2525SinglePoint.java
@@ -82,11 +82,9 @@ public class MilStd2525SinglePoint extends FeatureRenderableMapping<MilStdSymbol
     // Takes a symbol and initializes default color values for labels.
     private static void initializeDefaultAttributes(MilStdSymbol symbol) {
         // Initializes default text color to black and white.
-        final IGeoColor black = new EmpGeoColor(0, 0, 0);
-        final IGeoColor white = new EmpGeoColor(255, 255, 255);
         final IGeoLabelStyle labelStyle = new GeoLabelStyle();
-        labelStyle.setColor(black);
-        labelStyle.setOutlineColor(white);
+        labelStyle.setColor(EmpGeoColor.BLACK);
+        labelStyle.setOutlineColor(EmpGeoColor.WHITE);
         symbol.setLabelStyle(labelStyle);
     }
 

--- a/mapengine/worldwind/apk/src/main/java/mil/emp3/worldwind/feature/MilStd2525SinglePoint.java
+++ b/mapengine/worldwind/apk/src/main/java/mil/emp3/worldwind/feature/MilStd2525SinglePoint.java
@@ -3,7 +3,9 @@ package mil.emp3.worldwind.feature;
 import android.util.Log;
 import android.util.SparseArray;
 
+import org.cmapi.primitives.GeoLabelStyle;
 import org.cmapi.primitives.IGeoColor;
+import org.cmapi.primitives.IGeoLabelStyle;
 import org.cmapi.primitives.IGeoPosition;
 
 import gov.nasa.worldwind.WorldWind;
@@ -43,9 +45,9 @@ public class MilStd2525SinglePoint extends FeatureRenderableMapping<MilStdSymbol
         this.placemark = new EMPPlacemark(this, position);
         this.sSymbolCode = symbol.getSymbolCode();
         this.oRenderer = iconRenderer;
+        initializeDefaultAttributes(symbol);
         this.setSymbolAttributes();
         this.setSymbolModifiers();
-        initializeDefaultAttributes(symbol);
         placemark.setPickDelegate(symbol);
         switch (symbol.getAltitudeMode()) {
             case RELATIVE_TO_GROUND:
@@ -82,8 +84,10 @@ public class MilStd2525SinglePoint extends FeatureRenderableMapping<MilStdSymbol
         // Initializes default text color to black and white.
         final IGeoColor black = new EmpGeoColor(0, 0, 0);
         final IGeoColor white = new EmpGeoColor(255, 255, 255);
-        symbol.setTextColor(black);
-        symbol.setTextBackgroundColor(white);
+        final IGeoLabelStyle labelStyle = new GeoLabelStyle();
+        labelStyle.setColor(black);
+        labelStyle.setOutlineColor(white);
+        symbol.setLabelStyle(labelStyle);
     }
 
     public SparseArray getSymbolModifiers() {
@@ -168,6 +172,7 @@ public class MilStd2525SinglePoint extends FeatureRenderableMapping<MilStdSymbol
     @Override
     public void setSelected(boolean selected) {
         super.setSelected(selected);
+        setSymbolAttributes();
         setSymbolModifiers();
     }
 

--- a/sdk/sdk-api/src/main/java/mil/emp3/api/MilStdSymbol.java
+++ b/sdk/sdk-api/src/main/java/mil/emp3/api/MilStdSymbol.java
@@ -1382,6 +1382,7 @@ public class MilStdSymbol extends Feature<IGeoMilSymbol> implements IGeoMilSymbo
     public SparseArray<String> getAttributes(int iIconSize, boolean selected, IGeoColor selectedStrokeColor, IGeoColor selectedTextColor) {
         IGeoColor strokeColor = null;
         IGeoColor textColor = null;
+        IGeoColor textBackgroundColor = null;
         SparseArray<String> oArray = new SparseArray<>();
         IGeoFillStyle oFillStyle = getFillStyle();
         IGeoStrokeStyle oStrokeStyle = getStrokeStyle();
@@ -1402,6 +1403,7 @@ public class MilStdSymbol extends Feature<IGeoMilSymbol> implements IGeoMilSymbo
             }
             if (labelStyle != null) {
                 textColor = labelStyle.getColor();
+                textBackgroundColor = labelStyle.getOutlineColor();
             }
         }
 
@@ -1423,6 +1425,10 @@ public class MilStdSymbol extends Feature<IGeoMilSymbol> implements IGeoMilSymbo
             // There is currently no way to change the font.
         }
 
+        if (textBackgroundColor != null) {
+            oArray.put(MilStdAttributes.TextBackgroundColor, "#" + ColorUtils.colorToString(textBackgroundColor));
+            // There is currently no way to change the font.
+        }
         if (isSinglePoint()) {
             oArray.put(MilStdAttributes.FontSize, "" + FontUtilities.getTextPixelSize(labelStyle, FontSizeModifierEnum.NORMAL));
         }

--- a/sdk/sdk-api/src/main/java/mil/emp3/api/MilStdSymbol.java
+++ b/sdk/sdk-api/src/main/java/mil/emp3/api/MilStdSymbol.java
@@ -1377,9 +1377,11 @@ public class MilStdSymbol extends Feature<IGeoMilSymbol> implements IGeoMilSymbo
      * @param selected               True if the feature is currenlt selected.
      * @param selectedStrokeColor    The stroke color for selected features.
      * @param selectedTextColor      The text color for selected features.
+     * @param selectedTextBackgroundColor      The text color for selected features.
      * @return SparseArray of attributes.
      */
-    public SparseArray<String> getAttributes(int iIconSize, boolean selected, IGeoColor selectedStrokeColor, IGeoColor selectedTextColor) {
+    public SparseArray<String> getAttributes(int iIconSize, boolean selected, IGeoColor selectedStrokeColor,
+                                             IGeoColor selectedTextColor, IGeoColor selectedTextBackgroundColor) {
         IGeoColor strokeColor = null;
         IGeoColor textColor = null;
         IGeoColor textBackgroundColor = null;
@@ -1397,6 +1399,7 @@ public class MilStdSymbol extends Feature<IGeoMilSymbol> implements IGeoMilSymbo
         if (selected) {
             strokeColor = selectedStrokeColor;
             textColor = selectedTextColor;
+            textBackgroundColor = selectedTextBackgroundColor;
         } else {
             if (oStrokeStyle != null) {
                 strokeColor = oStrokeStyle.getStrokeColor();
@@ -1404,6 +1407,10 @@ public class MilStdSymbol extends Feature<IGeoMilSymbol> implements IGeoMilSymbo
             if (labelStyle != null) {
                 textColor = labelStyle.getColor();
                 textBackgroundColor = labelStyle.getOutlineColor();
+            } else {
+                // set EMP default colors which are different from renderer default colors
+                textColor = EmpGeoColor.BLACK;
+                textBackgroundColor = EmpGeoColor.WHITE;
             }
         }
 
@@ -1422,13 +1429,12 @@ public class MilStdSymbol extends Feature<IGeoMilSymbol> implements IGeoMilSymbo
 
         if (textColor != null) {
             oArray.put(MilStdAttributes.TextColor, "#" + ColorUtils.colorToString(textColor));
-            // There is currently no way to change the font.
         }
 
         if (textBackgroundColor != null) {
             oArray.put(MilStdAttributes.TextBackgroundColor, "#" + ColorUtils.colorToString(textBackgroundColor));
-            // There is currently no way to change the font.
         }
+
         if (isSinglePoint()) {
             oArray.put(MilStdAttributes.FontSize, "" + FontUtilities.getTextPixelSize(labelStyle, FontSizeModifierEnum.NORMAL));
         }

--- a/sdk/sdk-api/src/main/java/mil/emp3/api/MilStdSymbol.java
+++ b/sdk/sdk-api/src/main/java/mil/emp3/api/MilStdSymbol.java
@@ -4,6 +4,7 @@ import android.util.SparseArray;
 
 import org.cmapi.primitives.GeoColor;
 import org.cmapi.primitives.GeoFillStyle;
+import org.cmapi.primitives.GeoLabelStyle;
 import org.cmapi.primitives.GeoMilSymbol;
 import org.cmapi.primitives.GeoPosition;
 import org.cmapi.primitives.GeoStrokeStyle;
@@ -1669,6 +1670,14 @@ public class MilStdSymbol extends Feature<IGeoMilSymbol> implements IGeoMilSymbo
         this.attributes.put(MilStdAttributes.LineColor, ColorUtils.colorToString(color));
     }
 
+    public void setTextColor(final IGeoColor color) {
+        this.attributes.put(MilStdAttributes.TextColor, ColorUtils.colorToString(color));
+    }
+
+    public void setTextBackgroundColor(final IGeoColor color) {
+        this.attributes.put(MilStdAttributes.TextBackgroundColor, ColorUtils.colorToString(color));
+    }
+
 
     /**
      * Convenience method to color fill, line and icon in one call.
@@ -1691,11 +1700,10 @@ public class MilStdSymbol extends Feature<IGeoMilSymbol> implements IGeoMilSymbo
     }
 
     private void initializeDefaultAttributes() {
-        // TODO - The addition of attributes in the symbol causes an empty sparse array.
-        // TODO - Previously we had passed null as the attribute array which caused the renderer to use preset defaults
-        // TODO - when rendering. We can no longer do that as we need to use the array. Find these defaults and set them,
-        // TODO - The below are only guesses. I have had difficulty finding the actual defaults.
-        this.attributes.put(MilStdAttributes.Scale, Integer.toString(DEFAULT_SCALE));
-        this.attributes.put(MilStdAttributes.PixelSize, Integer.toString(DEFAULT_PIXEL_SIZE));
+        // Initializes default text color to black and white.
+        final IGeoColor black = new EmpGeoColor(0, 0, 0);
+        final IGeoColor white = new EmpGeoColor(255, 255, 255);
+        this.setTextBackgroundColor(white);
+        this.setTextColor(black);
     }
 }

--- a/sdk/sdk-api/src/main/java/mil/emp3/api/utils/EmpGeoColor.java
+++ b/sdk/sdk-api/src/main/java/mil/emp3/api/utils/EmpGeoColor.java
@@ -32,4 +32,8 @@ public class EmpGeoColor extends GeoColor {
         super.setGreen(green);
         super.setBlue(blue);
     }
+
+    final public static EmpGeoColor YELLOW = new EmpGeoColor(1.0, 255, 255, 0);
+    final public static EmpGeoColor BLACK = new EmpGeoColor(1, 0, 0, 0);
+    final public static EmpGeoColor WHITE = new EmpGeoColor(1, 255, 255, 255);
 }

--- a/sdk/sdk-api/src/main/java/mil/emp3/api/utils/kml/KMLExportThread.java
+++ b/sdk/sdk-api/src/main/java/mil/emp3/api/utils/kml/KMLExportThread.java
@@ -391,7 +391,8 @@ public class KMLExportThread extends java.lang.Thread {
             final SparseArray<String> saAttr = feature.getAttributes(iconSize,
                     this.map.isSelected(feature),
                     this.map.getSelectedStrokeStyle().getStrokeColor(),
-                    this.map.getSelectedLabelStyle().getColor());
+                    this.map.getSelectedLabelStyle().getColor(),
+                    this.map.getSelectedLabelStyle().getOutlineColor());
 
             saAttr.put(MilStdAttributes.UseDashArray, "false");
             saAttr.delete(MilStdAttributes.FontSize); //.put(MilStdAttributes.FontSize, "13"); // 10 pts * 1/72 inch / pts * 96 pixel / inch
@@ -1160,7 +1161,8 @@ public class KMLExportThread extends java.lang.Thread {
             final SparseArray<String> modifiers = feature.getTGModifiers(KMLExportThread.this.eLabelSetting);
             final SparseArray<String> attributes = feature.getAttributes(KMLExportThread.this.map.getIconPixelSize(),
                     KMLExportThread.this.map.isSelected(feature), KMLExportThread.this.map.getSelectedStrokeStyle().getStrokeColor(),
-                    KMLExportThread.this.map.getSelectedLabelStyle().getColor());
+                    KMLExportThread.this.map.getSelectedLabelStyle().getColor(),
+                    KMLExportThread.this.map.getSelectedLabelStyle().getOutlineColor());
             final String altitudeModeStr = MilStdUtilities.geoAltitudeModeToString(feature.getAltitudeMode());
 
             attributes.put(MilStdAttributes.UseDashArray, "false");

--- a/sdk/sdk-api/src/main/java/mil/emp3/json/geoJson/GeoJsonExporter.java
+++ b/sdk/sdk-api/src/main/java/mil/emp3/json/geoJson/GeoJsonExporter.java
@@ -336,7 +336,8 @@ public class GeoJsonExporter extends Thread{
         SparseArray<String> saAttr = feature.getAttributes(iconSize,
                 this.map.isSelected(feature),
                 this.map.getSelectedStrokeStyle().getStrokeColor(),
-                this.map.getSelectedLabelStyle().getColor());
+                this.map.getSelectedLabelStyle().getColor(),
+                this.map.getSelectedLabelStyle().getOutlineColor());
 
         saAttr.put(MilStdAttributes.UseDashArray, "false");
 

--- a/sdk/sdk-core/aar/src/main/java/mil/emp3/core/storage/MapStatus.java
+++ b/sdk/sdk-core/aar/src/main/java/mil/emp3/core/storage/MapStatus.java
@@ -118,10 +118,10 @@ public abstract class MapStatus implements IMapStatus {
     protected MapStatus() {
         this.mapServiceHash = new HashMap<>();
         this.setIconSize(IconSizeEnum.SMALL);
-        IGeoColor color = new EmpGeoColor(1.0, 255, 255, 0);
-        this.selectedStrokeStyle.setStrokeColor(color);
+        this.selectedStrokeStyle.setStrokeColor(EmpGeoColor.YELLOW);
         this.selectedStrokeStyle.setStrokeWidth(3.0);
-        this.selectedLabelStyle.setColor(color);
+        this.selectedLabelStyle.setColor(EmpGeoColor.YELLOW);
+        this.selectedLabelStyle.setOutlineColor(EmpGeoColor.BLACK);
 
         this.bufferFillStyle.setFillColor(new EmpGeoColor(0.5, 255, 255, 0));
     }

--- a/sdk/sdk-core/aar/src/main/java/mil/emp3/core/utils/MilStdRenderer.java
+++ b/sdk/sdk-core/aar/src/main/java/mil/emp3/core/utils/MilStdRenderer.java
@@ -400,6 +400,10 @@ public class MilStdRenderer implements IMilStdRenderer {
         // All modifier text are the same color.
         armyc2.c2sd.renderer.utilities.Color renderTextColor = renderSymbol.getTextColor();
         IGeoColor textColor = new EmpGeoColor(renderTextColor.getAlpha(), renderTextColor.getRed(), renderTextColor.getGreen(), renderTextColor.getBlue());
+        armyc2.c2sd.renderer.utilities.Color renderTextBackgroundColor = renderSymbol.getTextBackgroundColor();
+        IGeoColor textBackgroundColor = new EmpGeoColor(renderTextBackgroundColor.getAlpha(),
+                renderTextBackgroundColor.getRed(), renderTextBackgroundColor.getGreen(),
+                renderTextBackgroundColor.getBlue());
 
         // Process the list of shapes.
         for(ShapeInfo shapeInfo: modifierShapeInfoList) {
@@ -425,9 +429,11 @@ public class MilStdRenderer implements IMilStdRenderer {
                     currentTextStyle = new GeoLabelStyle();
                     if ((null == symbolTextStyle) || (null == symbolTextStyle.getColor())) {
                         currentTextStyle.setColor(textColor);
+                        currentTextStyle.setOutlineColor(textBackgroundColor);
                         currentTextStyle.setSize(FontUtilities.DEFAULT_FONT_POINT_SIZE);
                     } else {
                         currentTextStyle.setColor(symbolTextStyle.getColor());
+                        currentTextStyle.setOutlineColor(symbolTextStyle.getOutlineColor());
                         currentTextStyle.setSize(symbolTextStyle.getSize());
                     }
                     if (selected) {

--- a/sdk/sdk-core/aar/src/main/java/mil/emp3/core/utils/MilStdRenderer.java
+++ b/sdk/sdk-core/aar/src/main/java/mil/emp3/core/utils/MilStdRenderer.java
@@ -390,9 +390,10 @@ public class MilStdRenderer implements IMilStdRenderer {
 
         // All modifier text are the same color.
         armyc2.c2sd.renderer.utilities.Color renderTextColor = renderSymbol.getTextColor();
-        IGeoColor textColor = new EmpGeoColor(renderTextColor.getAlpha(), renderTextColor.getRed(), renderTextColor.getGreen(), renderTextColor.getBlue());
+        IGeoColor textColor = new EmpGeoColor((double)renderTextColor.getAlpha()/255.0,
+                renderTextColor.getRed(), renderTextColor.getGreen(), renderTextColor.getBlue());
         armyc2.c2sd.renderer.utilities.Color renderTextBackgroundColor = renderSymbol.getTextBackgroundColor();
-        IGeoColor textBackgroundColor = new EmpGeoColor(renderTextBackgroundColor.getAlpha(),
+        IGeoColor textBackgroundColor = new EmpGeoColor((double)renderTextBackgroundColor.getAlpha()/255.0,
                 renderTextBackgroundColor.getRed(), renderTextBackgroundColor.getGreen(),
                 renderTextBackgroundColor.getBlue());
 

--- a/sdk/sdk-core/aar/src/main/java/mil/emp3/core/utils/MilStdRenderer.java
+++ b/sdk/sdk-core/aar/src/main/java/mil/emp3/core/utils/MilStdRenderer.java
@@ -166,6 +166,7 @@ public class MilStdRenderer implements IMilStdRenderer {
         int iIconSize = storageManager.getIconPixelSize(mapInstance);
         IGeoColor strokeColor = null;
         IGeoColor textColor = null;
+        IGeoColor textBackgroundColor = null;
         SparseArray<String> oArray = new SparseArray<>();
         IGeoFillStyle oFillStyle = feature.getFillStyle();
         IGeoStrokeStyle oStrokeStyle = feature.getStrokeStyle();
@@ -188,6 +189,7 @@ public class MilStdRenderer implements IMilStdRenderer {
             }
             if (labelStyle != null) {
                 textColor = labelStyle.getColor();
+                textBackgroundColor = labelStyle.getOutlineColor();
             }
         }
 
@@ -209,6 +211,10 @@ public class MilStdRenderer implements IMilStdRenderer {
             // There is currently no way to change the font.
         }
 
+        if (textBackgroundColor != null) {
+            oArray.put(MilStdAttributes.TextBackgroundColor, "#" + ColorUtils.colorToString(textBackgroundColor));
+            // There is currently no way to change the font.
+        }
         if (isMilStd && !((MilStdSymbol) feature).isSinglePoint()) {
             oArray.put(MilStdAttributes.FontSize, "" + FontUtilities.getTextPixelSize(labelStyle, FontSizeModifierEnum.NORMAL));
         }

--- a/sdk/sdk-core/aar/src/main/java/mil/emp3/core/utils/MilStdRenderer.java
+++ b/sdk/sdk-core/aar/src/main/java/mil/emp3/core/utils/MilStdRenderer.java
@@ -73,19 +73,6 @@ public class MilStdRenderer implements IMilStdRenderer {
 
     private boolean initialized;
 
-    private static IGeoColor black = new GeoColor();
-    private static IGeoColor white = new GeoColor();
-    static {
-        black.setAlpha(1.0);
-        black.setBlue(0);
-        black.setGreen(0);
-        black.setRed(0);
-        white.setAlpha(1.0);
-        white.setBlue(255);
-        white.setGreen(255);
-        white.setRed(255);
-    }
-
     private void initCheck() {
         if (!initialized) {
             init();

--- a/sdk/sdk-core/aar/src/main/java/mil/emp3/core/utils/MilStdRenderer.java
+++ b/sdk/sdk-core/aar/src/main/java/mil/emp3/core/utils/MilStdRenderer.java
@@ -170,6 +170,7 @@ public class MilStdRenderer implements IMilStdRenderer {
         if (selected) {
             strokeColor = storageManager.getSelectedStrokeStyle(mapInstance).getStrokeColor();
             textColor = storageManager.getSelectedLabelStyle(mapInstance).getColor();
+            textBackgroundColor = storageManager.getSelectedLabelStyle(mapInstance).getOutlineColor();
         } else {
             if (oStrokeStyle != null) {
                 strokeColor = oStrokeStyle.getStrokeColor();
@@ -177,6 +178,10 @@ public class MilStdRenderer implements IMilStdRenderer {
             if (labelStyle != null) {
                 textColor = labelStyle.getColor();
                 textBackgroundColor = labelStyle.getOutlineColor();
+            } else {
+                // set EMP default colors which are different from renderer default colors
+                textColor = EmpGeoColor.BLACK;
+                textBackgroundColor = EmpGeoColor.WHITE;
             }
         }
 
@@ -195,13 +200,12 @@ public class MilStdRenderer implements IMilStdRenderer {
 
         if (textColor != null) {
             oArray.put(MilStdAttributes.TextColor, "#" + ColorUtils.colorToString(textColor));
-            // There is currently no way to change the font.
         }
 
         if (textBackgroundColor != null) {
             oArray.put(MilStdAttributes.TextBackgroundColor, "#" + ColorUtils.colorToString(textBackgroundColor));
-            // There is currently no way to change the font.
         }
+
         if (isMilStd && !((MilStdSymbol) feature).isSinglePoint()) {
             oArray.put(MilStdAttributes.FontSize, "" + FontUtilities.getTextPixelSize(labelStyle, FontSizeModifierEnum.NORMAL));
         }


### PR DESCRIPTION
This change should be merged after https://github.com/missioncommand/emp3-android/pull/404 which fixes a mistake made with rendering attributes.

This merge request closes  #377 

## Proposed Changes

  - Adds methods to configure text outline and fill color. 

