### PR TITLE
Mac os compatability issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ build/
 
 .nb-gradle/
 
+local.properties
+
 /.nb-gradle-properties
 
 # Keystore files

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ build/
 
 .nb-gradle/
 
-local.properties
-
 /.nb-gradle-properties
 
 # Keystore files

--- a/3rdpartylibrary/google-maps-android-cmgn/build.gradle
+++ b/3rdpartylibrary/google-maps-android-cmgn/build.gradle
@@ -8,7 +8,9 @@ targetCompatibility = rootProject.targetCompatibility
 
 dependencies {
     implementation   ("${cmapi_group_name}:${cmapi_jvm_artifact_name}:${version_cmapi}")
-    compileOnly files("${System.getenv("ANDROID_HOME")}/platforms/android-${android_compileSdkVersion}/android.jar")
+    Properties localProps = new Properties()
+    localProps.load(project.rootProject.file('local.properties').newDataInputStream())
+    compileOnly files("${localProps.getProperty('sdk.dir')}/platforms/android-${android_compileSdkVersion}/android.jar")
 }
 
 publishing {

--- a/geolib/build.gradle
+++ b/geolib/build.gradle
@@ -15,7 +15,9 @@ configurations {
 }
 dependencies {
     implementation         ("net.sf.geographiclib:GeographicLib-Java:1.49")
-    compileOnly files      ("${System.getenv("ANDROID_HOME")}/platforms/android-${android_compileSdkVersion}/android.jar")
+    Properties localProps = new Properties()
+    localProps.load(project.rootProject.file('local.properties').newDataInputStream())
+    compileOnly files("${localProps.getProperty('sdk.dir')}/platforms/android-${android_compileSdkVersion}/android.jar")
     testImplementation 'junit:junit:4.12'
 }
 

--- a/local.properties
+++ b/local.properties
@@ -1,4 +1,0 @@
-# Hard coded local.properties for travis ci.
-# This file will be overwritten by android studio upon opening the project to point to your local
-# android sdk.
-sdk.dir=/usr/local/android-sdk

--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,4 @@
+# Hard coded local.properties for travis ci.
+# This file will be overwritten by android studio upon opening the project to point to your local
+# android sdk.
+sdk.dir=/usr/local/android-sdk

--- a/sdk/sdk-api/build.gradle
+++ b/sdk/sdk-api/build.gradle
@@ -23,7 +23,9 @@ dependencies {
     implementation         ("net.sf.geographiclib:GeographicLib-Java:1.49")
     implementation         ("mil.army.missioncommand:mirrorcache-api")
     compileOnly            (group: 'mil.army.missioncommand', name: 'mil-sym-android-renderer', ext: 'jar') { transitive = true }
-    compileOnly files      ("${System.getenv("ANDROID_HOME")}/platforms/android-${android_compileSdkVersion}/android.jar")
+    Properties localProps = new Properties()
+    localProps.load(project.rootProject.file('local.properties').newDataInputStream())
+    compileOnly files("${localProps.getProperty('sdk.dir')}/platforms/android-${android_compileSdkVersion}/android.jar")
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
Fixes #422 

## Proposed Changes
Uses local.properties file to point to android sdk instead of environment variable as mac os android studio cannot use system.getenv calls.

Courtesy of @jpettitt1
